### PR TITLE
Add `hlint` configuration file and bring code into compliance.

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,0 +1,2 @@
+- ignore: {name: "Reduce duplication"}
+  # This is a decision left to developers and reviewers.

--- a/src/Codec/Binary/Bech32/Internal.hs
+++ b/src/Codec/Binary/Bech32/Internal.hs
@@ -468,7 +468,7 @@ instance Ix Word5 where
     inRange (m,n) i = m <= i && i <= n
 
 word5 :: Integral a => a -> Word5
-word5 x = Word5 ((fromIntegral x) .&. 31)
+word5 x = Word5 (fromIntegral x .&. 31)
 {-# INLINE word5 #-}
 {-# SPECIALIZE INLINE word5 :: Word8 -> Word5 #-}
 
@@ -483,7 +483,7 @@ polymod values = foldl' go 1 values .&. 0x3fffffff
     go chk value =
         foldl' xor chk' [g | (g, i) <- zip generator [25 ..], testBit chk i]
       where
-        chk' = chk .<<. 5 `xor` (fromWord5 value)
+        chk' = chk .<<. 5 `xor` fromWord5 value
         generator =
             [ 0x3b6a57b2
             , 0x26508e6d
@@ -751,7 +751,7 @@ locateErrors residue len
       l_s1 /= -1 &&
       l_s2 /= -1 && (2 * l_s1 - l_s2 - l_s0 + 2046) `mod` 1023 == 0 =
           let p1 = (l_s1 - l_s0 + 1023) `mod` 1023 in
-          if (p1 >= len) then [] else
+          if p1 >= len then [] else
           let l_e1 = l_s0 + (1023 - 997) * p1 in
           [p1 | l_e1 `mod` 33 <= 0]
     | otherwise =
@@ -776,7 +776,7 @@ locateErrors residue len
         | s1_s0p2 == 0      = []
         | l_e2 `mod` 33 > 0 = []
         | l_e1 `mod` 33 > 0 = []
-        | (p1 < p2)         = [p1, p2]
+        | p1 < p2           = [p1, p2]
         | otherwise         = [p2, p1]
       where
         inv_p1_p2 = 1023 -

--- a/test/Codec/Binary/Bech32Spec.hs
+++ b/test/Codec/Binary/Bech32Spec.hs
@@ -97,9 +97,9 @@ spec = do
                         T.breakOnEnd (T.singleton separatorChar) checksum
                 let Just (first, rest') = T.uncons rest
                 let checksumCorrupted =
-                        (hrp `T.snoc` (chr (ord first `xor` 1)))
+                        (hrp `T.snoc` chr (ord first `xor` 1))
                         `T.append` rest'
-                (Bech32.decode checksumCorrupted) `shouldSatisfy` isLeft'
+                Bech32.decode checksumCorrupted `shouldSatisfy` isLeft'
                 -- test that re-encoding the decoded checksum results in
                 -- the same checksum.
                 let checksumEncoded = Bech32.encode resultHRP resultData
@@ -109,7 +109,7 @@ spec = do
     describe "Invalid Checksums" $ forM_ invalidChecksums $
         \(checksum, expect) ->
             it (T.unpack checksum) $
-                Bech32.decode checksum `shouldBe` (Left expect)
+                Bech32.decode checksum `shouldBe` Left expect
 
     describe "More Encoding/Decoding Cases" $ do
         it "length > maximum" $ do
@@ -301,24 +301,24 @@ spec = do
                         (Bech32.decode corruptedString `shouldBe` Left
                             StringToDecodeHasMixedCase)
 
-    describe "Roundtrip (encode . decode)" $ do
+    describe "Roundtrip (encode . decode)" $
         it "Can perform roundtrip for valid data" $ property $ \(hrp, dp) ->
             (eitherToMaybe (Bech32.encode hrp dp)
                 >>= eitherToMaybe . Bech32.decode) === Just (hrp, dp)
 
-    describe "Roundtrip (dataPartToBytes . dataPartFromBytes)" $ do
+    describe "Roundtrip (dataPartToBytes . dataPartFromBytes)" $
         it "Can perform roundtrip base conversion" $ property $ \bs ->
             (Bech32.dataPartToBytes . Bech32.dataPartFromBytes) bs === Just bs
 
-    describe "Roundtrip (dataPartFromText . dataPartToText)" $ do
+    describe "Roundtrip (dataPartFromText . dataPartToText)" $
         it "Can perform roundtrip conversion" $ property $ \dp ->
             (Bech32.dataPartFromText . Bech32.dataPartToText) dp === Just dp
 
-    describe "Roundtrip (dataPartFromWords . dataPartToWords)" $ do
+    describe "Roundtrip (dataPartFromWords . dataPartToWords)" $
         it "Can perform roundtrip conversion" $ property $ \dp ->
             (Bech32.dataPartFromWords . Bech32.dataPartToWords) dp === dp
 
-    describe "Roundtrip (dataPartToWords . dataPartFromWords)" $ do
+    describe "Roundtrip (dataPartToWords . dataPartFromWords)" $
         it "Can perform roundtrip conversion" $ property $ \ws ->
             (Bech32.dataPartToWords . Bech32.dataPartFromWords) ws === ws
 
@@ -327,16 +327,16 @@ spec = do
             (Bech32.humanReadablePartFromText . Bech32.humanReadablePartToText)
                 hrp === Right hrp
 
-    describe "Roundtrip (toBase256 . toBase32)" $ do
+    describe "Roundtrip (toBase256 . toBase32)" $
         it "Can perform roundtrip base conversion" $ property $ \ws ->
             (Bech32.toBase256 . Bech32.toBase32) ws === Just ws
 
-    describe "Roundtrip (toBase32 . toBase256)" $ do
+    describe "Roundtrip (toBase32 . toBase256)" $
         it "Can perform roundtrip base conversion" $ property $ \ws ->
             isJust (Bech32.toBase256 ws) ==>
                 (Bech32.toBase32 <$> Bech32.toBase256 ws) === Just ws
 
-    describe "Roundtrip (dataCharToWord . dataCharFromWord)" $ do
+    describe "Roundtrip (dataCharToWord . dataCharFromWord)" $
         it "can perform roundtrip character set conversion" $
             property $ \w ->
                 Bech32.dataCharToWord (toLower (Bech32.dataCharFromWord w))
@@ -400,7 +400,7 @@ spec = do
                     .&&.
                     (outputWordsSuffix `shouldSatisfy` all (== 0))
 
-    describe "Pointless test to trigger coverage on derived instances" $ do
+    describe "Pointless test to trigger coverage on derived instances" $
         it (show $ humanReadablePartFromText $ T.pack "ca") True
 
 -- Taken from the BIP 0173 specification: https://git.io/fjBIN
@@ -514,8 +514,8 @@ bech32CharSet :: Set Char
 bech32CharSet =
     Set.filter (not . isUpper) $
         Set.fromList [humanReadableCharMinBound .. humanReadableCharMaxBound]
-            `Set.union` (Set.singleton separatorChar)
-            `Set.union` (Set.fromList Bech32.dataCharList)
+            `Set.union` Set.singleton separatorChar
+            `Set.union` Set.fromList Bech32.dataCharList
 
 -- | Find the index of an element in a sorted vector using simple binary search.
 sortedVectorElemIndex :: Ord a => a -> Vector a -> Maybe Int


### PR DESCRIPTION
This PR does two things:

1. Adds a basic `hlint` configuration file, with an exception for the "Reduce duplication" rule.
2. Brings code into compliance with `hlint`, so that the result of running `hlint` over the code base will not produce any suggestions.

A future PR will add `hlint` to CI.