### PR TITLE
Add function `unsafeHumanReadablePartFromText`.

### DIFF
--- a/bech32.cabal
+++ b/bech32.cabal
@@ -49,6 +49,7 @@ library
   exposed-modules:
       Codec.Binary.Bech32
       Codec.Binary.Bech32.Internal
+      Codec.Binary.Bech32.Unsafe
 
 test-suite bech32-test
   default-language:

--- a/src/Codec/Binary/Bech32/Unsafe.hs
+++ b/src/Codec/Binary/Bech32/Unsafe.hs
@@ -1,0 +1,14 @@
+-- |
+-- Copyright: © 2020 IOHK
+-- License: Apache-2.0
+--
+-- Unsafe functions for manipulating Bech32 strings.
+--
+module Codec.Binary.Bech32.Unsafe
+    (
+      -- * Human-Readable Part
+      unsafeHumanReadablePartFromText
+    )
+    where
+
+import Codec.Binary.Bech32.Internal


### PR DESCRIPTION
This PR:

- [x] Adds function **`unsafeHumanReadablePartFromText`**, which is similar to `humanReadablePartFromText`, except that it throws a runtime exception when provided with an invalid input.
- [x] Adds simple unit tests to check that `unsafeHumanReadablePartFromText` throws exceptions appropriately. (Note that the original `humanReadablePartFromText` function is already tested with property tests.)
- [x] Exports the `unsafeHumanReadablePartFromText` function from a new module `Codec.Binary.Bech32.Unsafe`.