### PR TITLE
Add tests for parsing of human readable prefixes from text.

### DIFF
--- a/src/Codec/Binary/Bech32/Internal.hs
+++ b/src/Codec/Binary/Bech32/Internal.hs
@@ -54,6 +54,7 @@ module Codec.Binary.Bech32.Internal
     , humanReadablePartToWords
     , humanReadablePartMinLength
     , humanReadablePartMaxLength
+    , humanReadableCharIsValid
     , humanReadableCharMinBound
     , humanReadableCharMaxBound
 

--- a/test/Codec/Binary/Bech32Spec.hs
+++ b/test/Codec/Binary/Bech32Spec.hs
@@ -120,15 +120,25 @@ spec = do
 
     describe "Parsing human-readable parts from text" $ do
 
+        describe "Known-good human readable parts parse correctly." $
+            forM_ validHumanReadableParts $ \hrp ->
+                it (T.unpack hrp) $
+                    (humanReadablePartToText <$> humanReadablePartFromText hrp)
+                    `shouldBe` Right hrp
+
+        describe "Known-bad human readable parts fail to parse." $
+            forM_ invalidHumanReadableParts $ \hrp ->
+                it (T.unpack hrp) $
+                    humanReadablePartFromText hrp `shouldSatisfy` isLeft'
+
         it "Characters are checked correctly for validity." $
             property $ \(HumanReadablePartWithSuspiciousChars hrp) ->
                 let isValid = T.all humanReadableCharIsValid hrp
-                    invalidError =
-                        HumanReadablePartContainsInvalidChars $
-                            CharPosition . fst <$>
-                            filter
-                                ((not . humanReadableCharIsValid) . snd)
-                                ([0 .. ] `zip` T.unpack hrp)
+                    invalidError = HumanReadablePartContainsInvalidChars $
+                        CharPosition . fst <$>
+                        filter
+                            ((not . humanReadableCharIsValid) . snd)
+                            ([0 .. ] `zip` T.unpack hrp)
                 in
                 checkCoverage
                     $ cover 10 isValid
@@ -464,6 +474,22 @@ spec = do
 
     describe "Pointless test to trigger coverage on derived instances" $
         it (show $ humanReadablePartFromText $ T.pack "ca") True
+
+-- Taken from the BIP 0173 specification: https://git.io/fjBIN
+validHumanReadableParts :: [Text]
+validHumanReadableParts =
+    [ "addr"
+    , "ca"
+    , "bc"
+    , "tb"
+    , "xprv"
+    ]
+
+invalidHumanReadableParts :: [Text]
+invalidHumanReadableParts =
+    [ "鑫"
+    , "臥虎藏龍"
+    ]
 
 -- Taken from the BIP 0173 specification: https://git.io/fjBIN
 validBech32Strings :: [Text]

--- a/test/Codec/Binary/Bech32Spec.hs
+++ b/test/Codec/Binary/Bech32Spec.hs
@@ -72,6 +72,7 @@ import Test.QuickCheck
     , counterexample
     , cover
     , elements
+    , frequency
     , oneof
     , property
     , withMaxSuccess
@@ -707,13 +708,26 @@ instance Arbitrary HumanReadablePartWithSuspiciousChars where
         chars <- replicateM len genChar
         return $ HumanReadablePartWithSuspiciousChars $ T.pack chars
       where
+        genChar = frequency
+            [ (98, genCharValid)
+            , ( 1, genCharBelowMinBound)
+            , ( 1, genCharAboveMaxBound)
+            ]
+        genCharValid = choose
+            ( humanReadableCharMinBound
+            , humanReadableCharMaxBound
+            )
+        genCharBelowMinBound = choose
+            ( toEnum 0
+            , toEnum (fromEnum humanReadableCharMinBound - 1)
+            )
+        genCharAboveMaxBound = choose
+            ( toEnum (fromEnum humanReadableCharMaxBound + 1)
+            , toEnum (fromEnum humanReadableCharMaxBound * 2)
+            )
         genLength = choose
             ( humanReadablePartMinLength
             , humanReadablePartMaxLength
-            )
-        genChar = choose
-            ( pred humanReadableCharMinBound
-            , succ humanReadableCharMaxBound
             )
 
 -- | A human-readable part that may (or may not) be too long or too short.

--- a/test/Codec/Binary/Bech32Spec.hs
+++ b/test/Codec/Binary/Bech32Spec.hs
@@ -695,6 +695,8 @@ instance Arbitrary HumanReadablePart where
       where
         chars = humanReadablePartToText hrp
 
+-- | A human-readable part that may (or may not) contain one or more invalid
+--   characters.
 newtype HumanReadablePartWithSuspiciousChars =
     HumanReadablePartWithSuspiciousChars Text
     deriving (Eq, Show)
@@ -714,6 +716,7 @@ instance Arbitrary HumanReadablePartWithSuspiciousChars where
             , succ humanReadableCharMaxBound
             )
 
+-- | A human-readable part that may (or may not) be too long or too short.
 newtype HumanReadablePartWithSuspiciousLength =
     HumanReadablePartWithSuspiciousLength Text
     deriving (Eq, Show)


### PR DESCRIPTION
This PR adds tests relating to the parsing of Bech32 human-readable prefixes (HRPs) from text.

In particular, we test that:

- [x] HRPs of incorrect lengths are handled correctly.
- [x] HRPs containing invalid characters are handled correctly.
- [x] known-good HRPs parse successfully.
- [x] known-bad HRPs fail to parse.
