### PR TITLE
Miscellaneous improvements to Haddock documentation.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright © 2018-2019 IOHK
+   Copyright © 2019-2020 IOHK
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/bech32.cabal
+++ b/bech32.cabal
@@ -5,7 +5,7 @@ description:   Implementation of the Bech32 cryptocurrency address format docume
                BIP (Bitcoin Improvement Proposal) 0173.
 author:        IOHK Engineering Team
 maintainer:    operations@iohk.io, erikd@mega-nerd.com
-copyright:     2017 Marko Bencun, 2019 IOHK
+copyright:     2017 Marko Bencun, 2019-2020 IOHK
 license:       Apache-2.0
 license-file:  LICENSE
 homepage:      https://github.com/input-output-hk/bech32

--- a/src/Codec/Binary/Bech32.hs
+++ b/src/Codec/Binary/Bech32.hs
@@ -1,5 +1,5 @@
 -- |
--- Copyright: © 2017 Marko Bencun, 2018-2019 IOHK
+-- Copyright: © 2017 Marko Bencun, 2019-2020 IOHK
 -- License: Apache-2.0
 --
 -- Implementation of the [Bech32]

--- a/src/Codec/Binary/Bech32.hs
+++ b/src/Codec/Binary/Bech32.hs
@@ -6,32 +6,47 @@
 -- (https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki)
 -- address format.
 --
--- From an original implementation by Marko Bencun:
---
--- [sipa/bech32](https://github.com/sipa/bech32/tree/bdc264f84014c234e908d72026b7b780122be11f/ref/haskell)
+-- Based on an [original implementation](https://github.com/sipa/bech32/tree/bdc264f84014c234e908d72026b7b780122be11f/ref/haskell)
+-- by [Marko Bencun](https://github.com/sipa).
 
 module Codec.Binary.Bech32
     (
-      -- * Encoding & Decoding
+    -- * Encoding
       encode
-    , encodeLenient
-    , EncodingError (..)
+
+    -- * Decoding
     , decode
-    , decodeLenient
+
+    -- * Error handling
+    , EncodingError (..)
     , DecodingError (..)
 
-      -- * Data Part
+    -- * Encoding data payloads
     , DataPart
     , dataPartFromBytes
     , dataPartFromText
     , dataPartToBytes
     , dataPartToText
 
-      -- * Human-Readable Part
+    -- * Encoding human-readable prefixes
     , HumanReadablePart
     , HumanReadablePartError (..)
     , humanReadablePartFromText
     , humanReadablePartToText
+
+    -- * Encoding with greater leniency
+    , encodeLenient
+    , decodeLenient
+
+    -- * Constants
+    , dataCharList
+    , encodedStringMaxLength
+    , encodedStringMinLength
+    , humanReadablePartMinLength
+    , humanReadablePartMaxLength
+    , humanReadableCharMinBound
+    , humanReadableCharMaxBound
+    , separatorChar
     ) where
 
 import Codec.Binary.Bech32.Internal

--- a/src/Codec/Binary/Bech32/Internal.hs
+++ b/src/Codec/Binary/Bech32/Internal.hs
@@ -7,7 +7,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 -- |
--- Copyright: © 2017 Marko Bencun, 2018-2019 IOHK
+-- Copyright: © 2017 Marko Bencun, 2019-2020 IOHK
 -- License: Apache-2.0
 --
 -- Implementation of the [Bech32]


### PR DESCRIPTION
This PR:

 - Adds structure to the Haddock documentation, so that related concepts are grouped together.
- Adds basic examples to the functions `encode` and `decode`, so that a beginning user will be able to see at a glance how to use the library.
- Adds Haddock documentation comments to certain constructors that previously didn't have any.
- Increments the latest copyright year to 2020 (for IOHK).
- Corrects the erroneous earliest copyright year from 2018 to 2019 (for IOHK). (We only started working on this in 2019, so it makes no sense to list 2018 as a starting year.)