### PR TITLE
[CI Experiment] Deliberately cause a test to fail.

### DIFF
--- a/src/Codec/Binary/Bech32/Internal.hs
+++ b/src/Codec/Binary/Bech32/Internal.hs
@@ -161,7 +161,7 @@ dataPartToBytes dp = BS.pack <$>
 --
 dataPartFromText :: Text -> Maybe DataPart
 dataPartFromText text
-    | T.any (not . dataCharIsValid) textLower = Nothing
+    | T.any dataCharIsValid textLower = Nothing
     | otherwise = pure $ DataPart textLower
   where
     textLower = T.toLower text


### PR DESCRIPTION
**CI Experiment. Please do not merge!**

An experimental PR to check that CI is working correctly.

I changed one function in order to trigger the following test failure:
```hs
Failures:

  test/Codec/Binary/Bech32Spec.hs:387:9: 
  1) Codec.Binary.Bech32, Roundtrip (dataPartFromText . dataPartToText), Can perform roundtrip conversion
       Falsifiable (after 1 test and 2 shrinks):
         DataPart "4"
         Nothing /= Just (DataPart "4")

  To rerun use: --match "/Codec.Binary.Bech32/Roundtrip (dataPartFromText . dataPartToText)/Can perform roundtrip conversion/"

  test/Codec/Binary/Bech32Spec.hs:429:9: 
  2) Codec.Binary.Bech32, Constructors produce valid values, dataPartFromText
       Falsifiable (after 3 tests and 2 shrinks):
         [DataChar {getDataChar = 'q'}]
         input:  [DataChar {getDataChar = 'q'}]
         output: Nothing
         
         Nothing /= Just True

  To rerun use: --match "/Codec.Binary.Bech32/Constructors produce valid values/dataPartFromText/"
```


The Travis CI integration should also report a failure.