### PR TITLE
Bump upper bound for `base`.

### DIFF
--- a/bech32-th/bech32-th.cabal
+++ b/bech32-th/bech32-th.cabal
@@ -39,7 +39,7 @@ library
     ghc-options:
       -Werror
   build-depends:
-      base
+      base < 4.15
     , bech32 >= 1.0.2
     , template-haskell
     , text
@@ -65,7 +65,7 @@ test-suite bech32-th-test
     ghc-options:
       -Werror
   build-depends:
-      base < 4.14
+      base
     , bech32
     , bech32-th
     , hspec

--- a/bech32-th/bech32-th.cabal
+++ b/bech32-th/bech32-th.cabal
@@ -39,7 +39,7 @@ library
     ghc-options:
       -Werror
   build-depends:
-      base < 4.15
+      base >= 4.11.1.0 && < 4.15
     , bech32 >= 1.0.2
     , template-haskell
     , text

--- a/bech32/bech32.cabal
+++ b/bech32/bech32.cabal
@@ -39,7 +39,7 @@ library
       -Werror
   build-depends:
       array
-    , base                                  < 4.15
+    , base >= 4.11.1.0 && < 4.15
     , bytestring
     , containers
     , extra

--- a/bech32/bech32.cabal
+++ b/bech32/bech32.cabal
@@ -71,7 +71,7 @@ test-suite bech32-test
     , deepseq
     , extra
     , hspec
-    , QuickCheck
+    , QuickCheck >= 2.12
     , text
     , vector
   build-tools:

--- a/bech32/bech32.cabal
+++ b/bech32/bech32.cabal
@@ -39,7 +39,7 @@ library
       -Werror
   build-depends:
       array
-    , base                                  < 4.14
+    , base                                  < 4.15
     , bytestring
     , containers
     , extra


### PR DESCRIPTION
## Related Issue

https://github.com/commercialhaskell/stackage/issues/5365

## Summary

This PR bumps the upper bound on `base` for both:

- [x] `bech32`
- [x] `bech32-th`

This will allow the package to continue building with the GHC `8.10.*` series.

Additionally, this PR adds lower bounds for the following packages (determined experimentally):

- [x] `base`
- [x] `QuickCheck`

## Next Steps

After merging this PR, I plan to make a package metadata revision on Hackage.