### PR TITLE
Add bech32 to build-tools in the cabal file

### DIFF
--- a/bech32/bech32.cabal
+++ b/bech32/bech32.cabal
@@ -106,6 +106,7 @@ test-suite bech32-test
     , vector
   build-tools:
       hspec-discover
+    , bech32
   main-is:
       Main.hs
   other-modules:


### PR DESCRIPTION
If I run `cabal test all` for the first time, the test fails because the `bech32` executable is missing.  Adding `bech32` to `build-tools` will ensure it is built first and be in the `PATH` when the test runs.