### PR TITLE
Replacement human readable parts

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -21,7 +21,7 @@ jobs:
     - name: ✍  Check hlint and stylish
       run: |
         curl -sSL https://raw.github.com/ndmitchell/hlint/master/misc/run.sh | sh -s .
-        curl -sSL https://raw.github.com/jaspervdj/stylish-haskell/master/scripts/latest.sh | sh -s $(find . -type f -name "*.hs" ! -path "*.stack-work*") -i
+        curl -sSL https://raw.github.com/input-output-hk/adrestia/master/.haskell/stylish-haskell.sh | sh -s $(find . -type f -name '*.hs' ! -path '*.stack-work*') -i
         if [ -z "$(git status --porcelain)" ]; then
             echo "No style errors detected."
         else

--- a/bech32/bech32.cabal
+++ b/bech32/bech32.cabal
@@ -47,6 +47,7 @@ library
     , base >= 4.11.1.0 && < 4.15
     , bytestring
     , containers
+    , either
     , extra
     , text
   hs-source-dirs:

--- a/bech32/src/Codec/Binary/Bech32.hs
+++ b/bech32/src/Codec/Binary/Bech32.hs
@@ -44,6 +44,8 @@ module Codec.Binary.Bech32
     -- *** Conversion to and from Text
     , humanReadablePartFromText
     , humanReadablePartToText
+    -- *** Replace Human-Readable Prefix in Bech32 Text
+    , replaceHumanReadablePart
     -- *** Error Handling
     , HumanReadablePartError (..)
 

--- a/bech32/test/Codec/Binary/Bech32Spec.hs
+++ b/bech32/test/Codec/Binary/Bech32Spec.hs
@@ -19,6 +19,7 @@ import Codec.Binary.Bech32.Internal
     , DecodingError (..)
     , HumanReadablePart
     , HumanReadablePartError (..)
+    , ReplaceHrpError (..)
     , dataPartFromBytes
     , dataPartFromText
     , dataPartFromWords
@@ -31,6 +32,7 @@ import Codec.Binary.Bech32.Internal
     , humanReadablePartMaxLength
     , humanReadablePartMinLength
     , humanReadablePartToText
+    , replaceHumanReadablePart
     , separatorChar
     )
 import Control.DeepSeq
@@ -475,6 +477,18 @@ spec = do
 
     describe "Pointless test to trigger coverage on derived instances" $
         it (show $ humanReadablePartFromText $ T.pack "ca") True
+
+    describe "Replacing human-readable part in text" $ do
+        it "should always replace successfully when both hrps and dp are valid " $
+            property $ \dp hrp hrp' -> do
+                let (Right bech32txt) = Bech32.encode hrp dp
+                replaceHumanReadablePart bech32txt hrp' `shouldSatisfy` isRight
+        it "should always return the same decoding error upon replacement with valid hrp" $
+            forM_ invalidChecksums $ \(checksum, expect) ->
+                forM_ validHumanReadableParts $ \hrpTxt -> do
+                    let (Right hrp) = humanReadablePartFromText hrpTxt
+                    replaceHumanReadablePart checksum hrp `shouldBe`
+                        Left (ReplaceHrpErrorDecoding expect)
 
 -- Taken from the BIP 0173 specification: https://git.io/fjBIN
 validHumanReadableParts :: [Text]


### PR DESCRIPTION
The `replaceHumanReadablePart` function allows a caller to replace the human-readable part of valid bech32 string with a different human-readable part.