### PR TITLE
Add ghc-8.10.2 to build matrix

### DIFF
--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["8.6.5"]
+        ghc: ["8.6.5", "8.10.2"]
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
@@ -33,7 +33,7 @@ jobs:
       run: |
         case "$OS" in
           Windows_NT)   echo "CABAL_VERSION=3.4.0.0-rc5"  >> $GITHUB_ENV;;
-          *)            echo "CABAL_VERSION=3.4.0.0-rc4"  >> $GITHUB_ENV;;
+          *)            echo "CABAL_VERSION=3.4.0.0"      >> $GITHUB_ENV;;
         esac
 
     - name: 🧰 Setup Haskell


### PR DESCRIPTION
Thank you for merging the earlier PR https://github.com/input-output-hk/bech32/pull/28.

This follow up PR adds `ghc-8.10.2` to the build matrix to demonstrate a build error with the newer compiler that is relevant to https://github.com/input-output-hk/bech32/issues/27.