### PR TITLE
Fix stack builds in CI

### DIFF
--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -40,7 +40,7 @@ jobs:
       run: cabal update
 
     - name: 🛠 Cabal Configure
-      run: cabal configure --enable-tests --enable-benchmarks --write-ghc-environment-files=always
+      run: cabal configure -frelease --enable-tests --enable-benchmarks --write-ghc-environment-files=always
 
     - name: 💾 Record dependencies
       run: |

--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -7,7 +7,7 @@ on:
     branches: [ "master" ]
 
 jobs:
-  build:
+  cabal_build:
     runs-on: ${{ matrix.os }}
 
     defaults:
@@ -76,9 +76,9 @@ jobs:
         name: ${{ matrix.os }}-exe
         path: bin
 
-  check:
-    needs: build
-    runs-on: ubuntu-latest
+  cabal:
+    needs: cabal_build
+    runs-on: ubuntu-20.04
 
     steps:
     - name: 📥 Checkout repository

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -20,11 +20,16 @@ jobs:
       with:
         apt-get: libgmp-dev
 
-    - name: 📥 Checkout repository
-      uses: actions/checkout@v1
+    - name: 🧰 Setup Haskell
+      uses: haskell/actions/setup@v1
+      with:
+        ghc-version: '8.6.5'
+        cabal-version: 'latest'
+        enable-stack: true
+        stack-version: '2.5.1'
 
-    - name: 🧰 Setup Stack
-      uses: timbod7/setup-stack@1f68f27c99094a718fe60a2790550aafd042f729
+    - name: 📥 Checkout repository
+      uses: actions/checkout@v2
 
     - name: 🔑 Variables
       id: variables

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -35,7 +35,7 @@ jobs:
       id: variables
       run: |
         echo ::set-output name=pkg_name::$(cat *.cabal | grep "name:" | sed "s/name:\s*\(.*\)/\1/")
-        echo ::set-output name=cache_key::$(md5sum stack.yaml | awk '{print $1}')
+        echo ::set-output name=cache_key::$(md5sum stack.yaml | awk '{print $1}')-$(stack --version | awk '{print $1}')
 
     - name: 💾 Cache Dependencies
       id: cache

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -8,7 +8,7 @@ on:
     tags: [ "*.*.*" ]
 
 jobs:
-  build:
+  stack:
     strategy:
       matrix:
         ghc: ["8.10.4"]
@@ -77,7 +77,7 @@ jobs:
         enable_jekyll: true
 
   release:
-    needs: [build]
+    needs: [stack]
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -11,7 +11,8 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        ghc: ["8.10.4"]
+        os: ["ubuntu-20.04"]
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -23,10 +24,10 @@ jobs:
     - name: 🧰 Setup Haskell
       uses: haskell/actions/setup@v1
       with:
-        ghc-version: '8.6.5'
-        cabal-version: 'latest'
+        ghc-version: ${{ matrix.ghc }}
+        cabal-version: '3.4.0.0'
         enable-stack: true
-        stack-version: '2.5.1'
+        stack-version: '2.7.1'
 
     - name: 📥 Checkout repository
       uses: actions/checkout@v2

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -8,7 +8,7 @@ on:
     tags: [ "*.*.*" ]
 
 jobs:
-  build:
+  style:
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 ### Haskell ###
 dist
 dist-*
-cabal-dev
 *.o
 *.hi
 *.chi
@@ -10,15 +9,13 @@ cabal-dev
 *.dyn_hi
 .hpc
 .hsenv
-.cabal-sandbox/
-cabal.sandbox.config
 *.prof
 *.aux
 *.hp
 *.eventlog
 .stack-work/
-cabal.project.local
-cabal.project.local~
+stack.yaml.lock
+cabal.project.local*
 .HTF/
 .ghc.environment.*
 .ghci
@@ -26,4 +23,3 @@ cabal.project.local~
 
 ### Nix ###
 result*
-.stack-to-nix.cache

--- a/bech32-th/bech32-th.cabal
+++ b/bech32-th/bech32-th.cabal
@@ -20,10 +20,10 @@ source-repository head
   type:     git
   location: https://github.com/input-output-hk/bech32.git
 
-flag werror
-    description: Enable `-Werror`
-    default: False
-    manual: True
+flag release
+  description: Strict compiler warning checks.
+  default: False
+  manual: True
 
 library
   default-language:
@@ -32,12 +32,9 @@ library
       NoImplicitPrelude
       OverloadedStrings
   ghc-options:
-      -Wall
-      -Wcompat
-      -fwarn-redundant-constraints
-  if (flag(werror))
-    ghc-options:
-      -Werror
+      -Wall -Wcompat -fwarn-redundant-constraints
+  if flag(release)
+    ghc-options: -Werror
   build-depends:
       base >= 4.11.1.0 && < 5
     , bech32 >= 1.0.2
@@ -59,11 +56,10 @@ test-suite bech32-th-test
   hs-source-dirs:
       test
   ghc-options:
-      -threaded -rtsopts -with-rtsopts=-N
       -Wall
-  if (flag(werror))
-    ghc-options:
-      -Werror
+      -threaded -rtsopts -with-rtsopts=-N
+  if flag(release)
+    ghc-options: -Werror
   build-depends:
       base
     , bech32

--- a/bech32-th/bech32-th.cabal
+++ b/bech32-th/bech32-th.cabal
@@ -39,7 +39,7 @@ library
     ghc-options:
       -Werror
   build-depends:
-      base >= 4.11.1.0 && < 4.15
+      base >= 4.11.1.0 && < 5
     , bech32 >= 1.0.2
     , template-haskell
     , text

--- a/bech32/bech32.cabal
+++ b/bech32/bech32.cabal
@@ -19,15 +19,15 @@ source-repository head
   type:     git
   location: https://github.com/input-output-hk/bech32.git
 
-flag werror
-    description: Enable `-Werror`
-    default: False
-    manual: True
-
 flag release
-  description: Compile executables for a release.
-  manual: True
+  description: Strict compiler warning checks.
   default: False
+  manual: True
+
+flag static
+  description: Try to build a static executable.
+  default: False
+  manual: True
 
 library
   default-language:
@@ -36,12 +36,9 @@ library
       NoImplicitPrelude
       OverloadedStrings
   ghc-options:
-      -Wall
-      -Wcompat
-      -fwarn-redundant-constraints
-  if (flag(werror))
-    ghc-options:
-      -Werror
+      -Wall -Wcompat -fwarn-redundant-constraints
+  if flag(release)
+    ghc-options: -Werror
   build-depends:
       array
     , base >= 4.11.1.0 && <5
@@ -61,7 +58,6 @@ executable bech32
       Paths_bech32
   hs-source-dirs:
       app
-  ghc-options: -Wall -Wcompat -fwarn-redundant-constraints -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       base
     , base58-bytestring
@@ -71,8 +67,13 @@ executable bech32
     , memory
     , optparse-applicative
     , text
-  if flag(release) && !os(darwin)
-    ghc-options: -Werror -static -O2
+  ghc-options:
+      -Wall -Wcompat -fwarn-redundant-constraints
+      -threaded -rtsopts -with-rtsopts=-N
+  if flag(release)
+    ghc-options: -Werror
+  if flag(static)
+    ghc-options: -static
     cc-options: -static
     ld-options: -static -pthread
   default-language: Haskell2010
@@ -85,11 +86,10 @@ test-suite bech32-test
   hs-source-dirs:
       test
   ghc-options:
-      -threaded -rtsopts -with-rtsopts=-N
       -Wall
-  if (flag(werror))
-    ghc-options:
-      -Werror
+      -threaded -rtsopts -with-rtsopts=-N
+  if flag(release)
+    ghc-options: -Werror
   build-depends:
       base
     , base58-bytestring

--- a/bech32/bech32.cabal
+++ b/bech32/bech32.cabal
@@ -71,7 +71,7 @@ executable bech32
     , memory
     , optparse-applicative
     , text
-  if flag(release)
+  if flag(release) && !os(darwin)
     ghc-options: -Werror -static -O2
     cc-options: -static
     ld-options: -static -pthread

--- a/bech32/bech32.cabal
+++ b/bech32/bech32.cabal
@@ -44,7 +44,7 @@ library
       -Werror
   build-depends:
       array
-    , base >= 4.11.1.0 && < 4.15
+    , base >= 4.11.1.0 && <5
     , bytestring
     , containers
     , extra
@@ -63,7 +63,7 @@ executable bech32
       app
   ghc-options: -Wall -Wcompat -fwarn-redundant-constraints -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      base >=4.7 && <5
+      base
     , base58-bytestring
     , bech32
     , bytestring

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,37 @@
+{ pkgs ? import (builtins.fetchTarball https://github.com/NixOS/nixpkgs/archive/8ea1ce75929f6d852911061e20717522e00ea47c.tar.gz) {}
+, compiler ? "ghc8104"
+# , compiler ? "ghc901"
+}:
+
+with pkgs;
+
+mkShell rec {
+  name = "bech32-env";
+  meta.platforms = lib.platforms.unix;
+
+  ghc = haskell.compiler.${compiler};
+
+  buildInputs = [
+    ghc
+    cabal-install
+    stack
+    nix
+  ]
+  ++ ghc.buildInputs
+  ++ lib.optional (stdenv.hostPlatform.libc == "glibc") glibcLocales
+  ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
+    Cocoa CoreServices libcxx libiconv
+  ]);
+
+  # Ensure that libz.so and other libraries are available to TH splices.
+  LD_LIBRARY_PATH = lib.makeLibraryPath buildInputs;
+
+  # Force a UTF-8 locale because many Haskell programs and tests
+  # assume this.
+  LANG = "en_US.UTF-8";
+
+  # Make the shell suitable for the stack nix integration
+  # <nixpkgs/pkgs/development/haskell-modules/generic-stack-builder.nix>
+  GIT_SSL_CAINFO = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+  STACK_IN_NIX_SHELL = "true";
+}

--- a/stack.yaml
+++ b/stack.yaml
@@ -7,3 +7,6 @@ packages:
 
 extra-deps:
 - base58-bytestring-0.1.0@sha256:a1da72ee89d5450bac1c792d9fcbe95ed7154ab7246f2172b57bd4fd9b5eab79,1913
+
+nix:
+  shell-file: shell.nix


### PR DESCRIPTION
(edited by @rvl)

We found that stack builds stopped working in CI.
The builds were failing due to linker errors.
Cabal builds worked, but it turns out this was because the Cabal build in CI did not enable `-frelease`.
The `release` build adds `-static` to the GHC options (quite important for releasing useful binaries).

It was working before and then stopped working because the GitHub actions workflow specified `ubuntu-latest` as the build environment. The problems started when GitHub updated their Ubuntu images from 18.04 to 20.04.

We could just downgrade to Ubuntu 18.04, but that's really old version, and our builds ought to work on recent distribution releases.

The solution is probably to add some extra linker flags or libraries, or something.

Thanks @newhoggy for reporting it in #34.

When this is fixed, we can make a Hackage release and get bech32 back into Stackage LTS (see commercialhaskell/stackage/issues/5432 and #31).