### PR TITLE
Filter whitespaces from bech32 stdin

### DIFF
--- a/bech32/app/Main.hs
+++ b/bech32/app/Main.hs
@@ -144,7 +144,7 @@ run :: Cmd -> IO ()
 run cmd = case cmd of
     VersionCmd -> putStrLn $ showVersion version
     RunCmd {prefix} -> do
-        source <- T.decodeUtf8 . B8.filter (/= '\n') <$> B8.hGetContents stdin
+        source <- T.strip . T.decodeUtf8 <$> B8.hGetContents stdin
         case prefix of
             Nothing  -> runDecode source
             Just hrp -> runEncode hrp source


### PR DESCRIPTION
Relates to https://github.com/input-output-hk/cardano-wallet/pull/3000#issuecomment-960873218.

Tested on Windows.
Before:
```
>echo addr_vk1xxly8nmfk0nr38a7fp002zkprfv562hll98mv9xntmgz4v9590cs4hujs4 | bech32
bech32: user error (StringToDecodeContainsInvalidChars [CharPosition 66,CharPosition 67])
```
After:
```
>echo addr_vk1xxly8nmfk0nr38a7fp002zkprfv562hll98mv9xntmgz4v9590cs4hujs4 | bech32
31be43cf69b3e6389fbe485ef50ac11a594d2afff94fb614d35ed02ab0b42bf1
```