### PR TITLE
Add upper version bound for `optparse-applicative`.

### DIFF
--- a/bech32/bech32.cabal
+++ b/bech32/bech32.cabal
@@ -65,7 +65,7 @@ executable bech32
     , bytestring
     , extra
     , memory
-    , optparse-applicative
+    , optparse-applicative >= 0.17.0.0 && < 0.18
     , text
   ghc-options:
       -Wall -Wcompat -fwarn-redundant-constraints


### PR DESCRIPTION
This PR fixes the build by introducing an upper version bound on for `optparse-applicative`.

This is a temporary workaround for https://github.com/input-output-hk/bech32/issues/51.