### PR TITLE
Bump minor version of `bech32` package to `1.1.3`.

### DIFF
--- a/bech32/ChangeLog.md
+++ b/bech32/ChangeLog.md
@@ -1,6 +1,12 @@
 # Changelog
 
 <!-- This ChangeLog follows a format specified by: https://keepachangelog.com/en/1.0.0/ -->
+## [1.1.3] - 2023-06-06
+
+### Fixed
+
+- Specify supported version bounds for `optparse-applicative`.
+
 ## [1.1.2] - 2021-11-05
 
 ### Fixed

--- a/bech32/bech32.cabal
+++ b/bech32/bech32.cabal
@@ -1,5 +1,5 @@
 name:          bech32
-version:       1.1.2
+version:       1.1.3
 synopsis:      Implementation of the Bech32 cryptocurrency address format (BIP 0173).
 description:   Implementation of the Bech32 cryptocurrency address format documented in the
                BIP (Bitcoin Improvement Proposal) 0173.


### PR DESCRIPTION
This PR prepares the repository for a new release of `bech32` (version `1.1.3`).