### PR TITLE
Prepare new release (`1.1.11`).

### DIFF
--- a/bech32-th/ChangeLog.md
+++ b/bech32-th/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for `bech32-th`
 
+## [1.1.11] - 2026-04-20
+
+- Revised upper version bounds for dependencies.
+
 ## [1.1.10] - 2026-01-30
 
 - Added support for GHC 9.14 series.

--- a/bech32-th/bech32-th.cabal
+++ b/bech32-th/bech32-th.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               bech32-th
-version:            1.1.10
+version:            1.1.11
 synopsis:           Template Haskell extensions to the Bech32 library.
 description:        Template Haskell extensions to the Bech32 library, including
                     quasi-quoters for compile-time checking of Bech32 string

--- a/bech32/ChangeLog.md
+++ b/bech32/ChangeLog.md
@@ -2,6 +2,10 @@
 
 <!-- This ChangeLog follows a format specified by: https://keepachangelog.com/en/1.0.0/ -->
 
+## [1.1.11] - 2026-04-20
+
+- Revised upper version bounds for dependencies.
+
 ## [1.1.10] - 2026-01-30
 
 - Added support for GHC 9.14 series.

--- a/bech32/bech32.cabal
+++ b/bech32/bech32.cabal
@@ -58,7 +58,7 @@ common dependency-prettyprinter-ansi-terminal
 common dependency-process
     build-depends:process                         >= 1.6.13.2   && < 1.7
 common dependency-QuickCheck
-    build-depends:QuickCheck                      >= 2.14.3     && < 2.18
+    build-depends:QuickCheck                      >= 2.14.3     && < 2.19
 common dependency-text
     build-depends:text                            >= 1.2.4.1    && < 2.2
 common dependency-vector

--- a/bech32/bech32.cabal
+++ b/bech32/bech32.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          bech32
-version:       1.1.10
+version:       1.1.11
 synopsis:      Implementation of the Bech32 cryptocurrency address format (BIP 0173).
 description:   Implementation of the Bech32 cryptocurrency address format documented in the
                BIP (Bitcoin Improvement Proposal) 0173.


### PR DESCRIPTION
Relaxes the upper version bound on `QuickCheck` to admit `2.18.x`, and bumps both `bech32` and `bech32-th` to `1.1.11`.

See:
- https://github.com/commercialhaskell/stackage/issues/7857#issue-3491457290